### PR TITLE
fix: remove hardcoded metaEvidence.json suffix from IPFS paths

### DIFF
--- a/src/sagas/api/get-meta-evidence.js
+++ b/src/sagas/api/get-meta-evidence.js
@@ -2,7 +2,7 @@ import statusHelper from '../../utils/api-status-helper'
 
 const getMetaEvidence = {
   getFile(ipfsHash) {
-    return fetch(`https://cdn.kleros.link/ipfs/${ipfsHash}/metaEvidence.json`)
+    return fetch(`https://cdn.kleros.link/ipfs/${ipfsHash}`)
       .then(statusHelper)
       .then(response => response.json())
       .catch(err => err)

--- a/src/sagas/arbitrable-transaction.js
+++ b/src/sagas/arbitrable-transaction.js
@@ -271,7 +271,7 @@ function* createArbitrabletx({
       multipleArbitrableTransactionEth.methods.createTransaction(
         arbitrabletxReceived.timeout.toString(),
         arbitrabletxReceived.receiver,
-        `/ipfs/${metaEvidenceIPFSHash}/metaEvidence.json`
+        `/ipfs/${metaEvidenceIPFSHash}`
       ).send,
       {
         from: accounts[0],
@@ -329,7 +329,7 @@ function* createArbitrabletx({
             arbitrabletxReceived.token.address,
             arbitrabletxReceived.timeout.toString(),
             arbitrabletxReceived.receiver,
-            `/ipfs/${metaEvidenceIPFSHash}/metaEvidence.json`
+            `/ipfs/${metaEvidenceIPFSHash}`
           ).send({
             from: accounts[0]
           })


### PR DESCRIPTION
Fixes #120.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the way metadata is fetched from IPFS by removing the specific file name from the URL, which now points directly to the IPFS hash instead of a specific `metaEvidence.json` file.

### Detailed summary
- In `src/sagas/api/get-meta-evidence.js`, the `getFile` method now fetches from `https://cdn.kleros.link/ipfs/${ipfsHash}` instead of `https://cdn.kleros.link/ipfs/${ipfsHash}/metaEvidence.json`.
- In `src/sagas/arbitrable-transaction.js`, the URL for fetching `metaEvidence` has been updated to `/ipfs/${metaEvidenceIPFSHash}` instead of `/ipfs/${metaEvidenceIPFSHash}/metaEvidence.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated how IPFS paths are handled when fetching meta evidence and creating new arbitrable transactions, removing the explicit reference to the JSON filename in the path. This change does not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->